### PR TITLE
feat: Add shadcn-compatible Spinner component

### DIFF
--- a/.changeset/pretty-pears-matter.md
+++ b/.changeset/pretty-pears-matter.md
@@ -1,0 +1,5 @@
+---
+"@scryjs/sdk": patch
+---
+
+git commit -m "feat(design-system): add proper Spinner component compatible with shadcn/ui"

--- a/.changeset/small-clocks-end.md
+++ b/.changeset/small-clocks-end.md
@@ -1,0 +1,5 @@
+---
+"@scryjs/sdk": patch
+---
+
+Add proper Spinner component compatible with shadcn/ui

--- a/apps/dashboard/app/org/[id]/_components/org-controls/project-search.tsx
+++ b/apps/dashboard/app/org/[id]/_components/org-controls/project-search.tsx
@@ -2,7 +2,8 @@
 
 import { useSearchParamsHandler } from '@/hooks/use-search-params-handler';
 import { Input, InputIcon, InputRoot } from '@repo/design-system/components/ui/input';
-import { Loader, Search } from 'lucide-react';
+import { Spinner } from '@repo/design-system/components/ui/spinner';
+import { Search } from 'lucide-react';
 
 export default function ProjectSearch() {
   const { loading, getParam, debouncedUpdateParam } = useSearchParamsHandler();
@@ -10,9 +11,7 @@ export default function ProjectSearch() {
   return (
     <>
       <InputRoot>
-        <InputIcon>
-          {loading ? <Loader className="animate-spin" /> : <Search />}
-        </InputIcon>
+        <InputIcon>{loading ? <Spinner size="icon" /> : <Search />}</InputIcon>
         <Input
           placeholder="Search projects..."
           onInput={(e) => debouncedUpdateParam('q', (e.target as HTMLInputElement).value)}

--- a/packages/design-system/src/components/ui/spinner.tsx
+++ b/packages/design-system/src/components/ui/spinner.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cn } from '@repo/design-system/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-const spinnerVariants = cva('animate-spin text-muted-foreground', {
+const spinnerVariants = cva('animate-spin text-muted-foreground/30', {
   variants: {
     size: {
       default: 'size-4',
@@ -26,17 +26,30 @@ function Spinner({ className, size, ...props }: SpinnerProps) {
       data-slot="spinner"
       className={cn(spinnerVariants({ size, className }))}
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
       {...props}
     >
-      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        className="text-foreground opacity-75"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        d="M12 2a10 10 0 0 1 10 10"
+      />
     </svg>
   );
 }

--- a/packages/design-system/src/components/ui/spinner.tsx
+++ b/packages/design-system/src/components/ui/spinner.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { cn } from '@repo/design-system/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const spinnerVariants = cva('animate-spin text-muted-foreground', {
+  variants: {
+    size: {
+      default: 'size-4',
+      sm: 'size-3',
+      lg: 'size-6',
+      icon: 'size-5',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+interface SpinnerProps
+  extends React.HTMLAttributes<SVGElement>,
+    VariantProps<typeof spinnerVariants> {}
+
+function Spinner({ className, size, ...props }: SpinnerProps) {
+  return (
+    <svg
+      data-slot="spinner"
+      className={cn(spinnerVariants({ size, className }))}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}
+
+export { Spinner };


### PR DESCRIPTION
Replaces hack implementation with a proper Spinner component that:
- Follows shadcn/ui conventions
- Provides size variants (sm, default, lg, icon)
- Uses cva for consistent styling
- Integrates with the existing component system

Updated project-search.tsx to use the new component.